### PR TITLE
feat(frontend): flatten hero showcase and add feature variants

### DIFF
--- a/frontend/src/components/heroes/HeroLaunchpad.astro
+++ b/frontend/src/components/heroes/HeroLaunchpad.astro
@@ -225,13 +225,14 @@ const bootSequence: Record<"linux" | "mac" | "windows", TerminalVariant> = {
   .launchpad-hero__title {
     margin: 0;
     font-size: clamp(2.85rem, 6vw, 5.2rem);
-    line-height: 1.02;
+    line-height: 1.1;
     letter-spacing: -0.04em;
   }
 
   .launchpad-hero__title span {
-    display: block;
-    padding-bottom: 0.08em;
+    display: inline-block;
+    padding-bottom: 0.2em;
+    line-height: 1.15;
   }
 
   .launchpad-hero__body {

--- a/frontend/src/components/heroes/HeroShowcase.astro
+++ b/frontend/src/components/heroes/HeroShowcase.astro
@@ -181,6 +181,10 @@ const heroBootstrapScript = `
       window.addEventListener("resize", updateFloating);
       updateFloating();
 
+      // reveal once the floating state has been resolved to avoid a flash
+      // of the top pill bar when the page loads already scrolled past the hero
+      requestAnimationFrame(() => picker.classList.add("is-ready"));
+
       root.dataset.bound = "true";
     }
 
@@ -304,6 +308,12 @@ const heroBootstrapScript = `
   /* ----- PICKER: shared ----- */
   .hero-picker {
     --picker-fab-size: 3rem;
+  }
+
+  .hero-picker:not(.is-ready) .hero-picker__options,
+  .hero-picker:not(.is-ready) .hero-picker__trigger {
+    visibility: hidden;
+    transition: none;
   }
 
   .hero-picker__options {

--- a/frontend/src/components/heroes/HeroShowcase.astro
+++ b/frontend/src/components/heroes/HeroShowcase.astro
@@ -118,7 +118,7 @@ const heroBootstrapScript = `
 `;
 ---
 
-<div class="hero-showcase mx-auto max-w-6xl px-4 pt-4 pb-4" data-hero-showcase>
+<div class="hero-showcase mx-auto max-w-6xl px-4" data-hero-showcase>
   {
     heroOptions.map((option, index) => (
       <input
@@ -187,23 +187,36 @@ const heroBootstrapScript = `
   }
 
   .hero-showcase__controls {
-    position: sticky;
-    top: 0.75rem;
-    z-index: 20;
+    position: fixed;
+    top: 4.75rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 40;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: center;
-    gap: 0.5rem;
-    padding: 0.5rem;
-    margin: 0 auto 1.25rem;
-    width: fit-content;
-    max-width: 100%;
+    gap: 0.4rem;
+    padding: 0.4rem;
+    max-width: calc(100vw - 1.5rem);
+    overflow-x: auto;
+    scrollbar-width: none;
     border-radius: var(--radius-full);
-    background: color-mix(in srgb, var(--color-bg-primary) 70%, transparent);
+    background: color-mix(in srgb, var(--color-bg-primary) 72%, transparent);
     backdrop-filter: blur(14px) saturate(140%);
     -webkit-backdrop-filter: blur(14px) saturate(140%);
     border: 1px solid
       color-mix(in srgb, var(--color-border-default) 65%, transparent);
+    box-shadow: 0 10px 30px -18px rgba(0, 0, 0, 0.45);
+  }
+
+  .hero-showcase__controls::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* reserve space so the fixed picker doesn't overlap the hero title */
+  .hero-showcase {
+    padding-top: 4.5rem;
+    padding-bottom: 1rem;
   }
 
   .hero-showcase__option {

--- a/frontend/src/components/heroes/HeroShowcase.astro
+++ b/frontend/src/components/heroes/HeroShowcase.astro
@@ -118,7 +118,7 @@ const heroBootstrapScript = `
 `;
 ---
 
-<div class="hero-showcase mx-auto max-w-6xl px-4 pt-6 pb-4" data-hero-showcase>
+<div class="hero-showcase mx-auto max-w-6xl px-4 pt-4 pb-4" data-hero-showcase>
   {
     heroOptions.map((option, index) => (
       <input
@@ -187,11 +187,23 @@ const heroBootstrapScript = `
   }
 
   .hero-showcase__controls {
+    position: sticky;
+    top: 0.75rem;
+    z-index: 20;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
     gap: 0.5rem;
-    padding: 0.25rem 0 1rem;
+    padding: 0.5rem;
+    margin: 0 auto 1.25rem;
+    width: fit-content;
+    max-width: 100%;
+    border-radius: var(--radius-full);
+    background: color-mix(in srgb, var(--color-bg-primary) 70%, transparent);
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    border: 1px solid
+      color-mix(in srgb, var(--color-border-default) 65%, transparent);
   }
 
   .hero-showcase__option {
@@ -328,5 +340,21 @@ const heroBootstrapScript = `
       opacity: 1;
       transform: translateY(0);
     }
+  }
+</style>
+
+<style is:global>
+  /* flatten child hero sections so they read as part of the page */
+  .hero-showcase__panel > .launchpad-hero,
+  .hero-showcase__panel > .command-hero,
+  .hero-showcase__panel > .blueprint-hero,
+  .hero-showcase__panel > .release-hero,
+  .hero-showcase__panel > .desk-hero,
+  .hero-showcase__panel > .signal-hero {
+    border: none;
+    background: none;
+    box-shadow: none;
+    border-radius: 0;
+    padding: clamp(1.5rem, 3vw, 3rem) 0;
   }
 </style>

--- a/frontend/src/components/heroes/HeroShowcase.astro
+++ b/frontend/src/components/heroes/HeroShowcase.astro
@@ -90,6 +90,7 @@ const heroBootstrapScript = `
       if (!nextInput) return;
       nextInput.checked = true;
       root.dataset.activeHero = nextInput.value;
+      document.documentElement.dataset.heroVariant = nextInput.value;
       localStorage.setItem(STORAGE_KEY, nextInput.value);
       syncUrl(nextInput.value);
     };
@@ -117,10 +118,7 @@ const heroBootstrapScript = `
 `;
 ---
 
-<section
-  class="gradient-bg-mesh hero-showcase px-4 pt-8 pb-24 md:pt-10 md:pb-28"
-  data-hero-showcase
->
+<div class="hero-showcase mx-auto max-w-6xl px-4 pt-6 pb-4" data-hero-showcase>
   {
     heroOptions.map((option, index) => (
       <input
@@ -136,62 +134,50 @@ const heroBootstrapScript = `
 
   <script is:inline set:html={heroBootstrapScript} />
 
-  <div class="hero-showcase__shell mx-auto max-w-6xl">
-    <div class="hero-showcase__toolbar">
-      <div class="hero-showcase__toolbar-copy">
-        <p id="hero-showcase-title" class="hero-showcase__eyebrow">
-          Homepage Intro
-        </p>
-        <span class="hero-showcase__meta">6 directions · saved locally</span>
-      </div>
+  <div
+    class="hero-showcase__controls"
+    role="radiogroup"
+    aria-label="Homepage hero style"
+  >
+    {
+      heroOptions.map((option) => (
+        <label
+          class="hero-showcase__option"
+          for={`hero-option-${option.id}`}
+          style={`--hero-option-accent: var(--color-accent-${option.accent})`}
+        >
+          <span class="hero-showcase__option-dot" />
+          <span class="hero-showcase__option-name">{option.label}</span>
+        </label>
+      ))
+    }
+  </div>
 
-      <div
-        class="hero-showcase__controls"
-        role="radiogroup"
-        aria-labelledby="hero-showcase-title"
-      >
-        {
-          heroOptions.map((option) => (
-            <label
-              class="hero-showcase__option"
-              for={`hero-option-${option.id}`}
-              style={`--hero-option-accent: var(--color-accent-${option.accent})`}
-            >
-              <span class="hero-showcase__option-dot" />
-              <span class="hero-showcase__option-name">{option.label}</span>
-            </label>
-          ))
-        }
-      </div>
+  <div class="hero-showcase__panels">
+    <div class:list={["hero-showcase__panel", heroOptions[0].panelClass]}>
+      <HeroLaunchpad />
     </div>
-
-    <div class="hero-showcase__panels">
-      <div class:list={["hero-showcase__panel", heroOptions[0].panelClass]}>
-        <HeroLaunchpad />
-      </div>
-      <div class:list={["hero-showcase__panel", heroOptions[1].panelClass]}>
-        <HeroControlRoom />
-      </div>
-      <div class:list={["hero-showcase__panel", heroOptions[2].panelClass]}>
-        <HeroBlueprint />
-      </div>
-      <div class:list={["hero-showcase__panel", heroOptions[3].panelClass]}>
-        <HeroReleaseTrain />
-      </div>
-      <div class:list={["hero-showcase__panel", heroOptions[4].panelClass]}>
-        <HeroOperatorDesk />
-      </div>
-      <div class:list={["hero-showcase__panel", heroOptions[5].panelClass]}>
-        <HeroSignalGrid />
-      </div>
+    <div class:list={["hero-showcase__panel", heroOptions[1].panelClass]}>
+      <HeroControlRoom />
+    </div>
+    <div class:list={["hero-showcase__panel", heroOptions[2].panelClass]}>
+      <HeroBlueprint />
+    </div>
+    <div class:list={["hero-showcase__panel", heroOptions[3].panelClass]}>
+      <HeroReleaseTrain />
+    </div>
+    <div class:list={["hero-showcase__panel", heroOptions[4].panelClass]}>
+      <HeroOperatorDesk />
+    </div>
+    <div class:list={["hero-showcase__panel", heroOptions[5].panelClass]}>
+      <HeroSignalGrid />
     </div>
   </div>
-</section>
+</div>
 
 <style>
   .hero-showcase {
     position: relative;
-    overflow: hidden;
   }
 
   .hero-showcase__input {
@@ -200,59 +186,25 @@ const heroBootstrapScript = `
     pointer-events: none;
   }
 
-  .hero-showcase__shell {
-    display: grid;
-    gap: 0.95rem;
-  }
-
-  .hero-showcase__toolbar {
-    display: grid;
-    gap: 0.75rem;
-    align-items: center;
-  }
-
-  .hero-showcase__toolbar-copy {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.55rem 0.75rem;
-  }
-
-  .hero-showcase__eyebrow {
-    margin: 0;
-    color: var(--color-accent-cyan);
-    font-family: var(--font-mono);
-    font-size: 0.78rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .hero-showcase__meta {
-    color: var(--color-fg-muted);
-    font-size: 0.84rem;
-    line-height: 1.4;
-  }
-
   .hero-showcase__controls {
     display: flex;
-    gap: 0.6rem;
-    overflow-x: auto;
-    padding: 0.05rem 0.05rem 0.35rem;
-    scrollbar-width: thin;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0 1rem;
   }
 
   .hero-showcase__option {
     position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
+    gap: 0.5rem;
     flex: 0 0 auto;
     border-radius: var(--radius-full);
     border: 1px solid
       color-mix(in srgb, var(--color-border-default) 88%, transparent);
     background: color-mix(in srgb, var(--color-bg-secondary) 76%, transparent);
-    padding: 0.62rem 0.9rem;
+    padding: 0.5rem 0.85rem;
     cursor: pointer;
     transition:
       transform 0.25s cubic-bezier(0.16, 1, 0.3, 1),
@@ -263,8 +215,8 @@ const heroBootstrapScript = `
 
   .hero-showcase__option-dot {
     display: inline-block;
-    height: 0.55rem;
-    width: 0.55rem;
+    height: 0.5rem;
+    width: 0.5rem;
     border-radius: 999px;
     background: var(--hero-option-accent);
     box-shadow: 0 0 0 0.22rem
@@ -281,8 +233,8 @@ const heroBootstrapScript = `
   }
 
   .hero-showcase__option-name {
-    font-size: 0.9rem;
-    font-weight: 700;
+    font-size: 0.85rem;
+    font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
   }
@@ -296,22 +248,22 @@ const heroBootstrapScript = `
   }
 
   #hero-option-launchpad:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-launchpad"],
   #hero-option-control-room:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-control-room"],
   #hero-option-blueprint:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-blueprint"],
   #hero-option-release-train:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-release-train"],
   #hero-option-operator-desk:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-operator-desk"],
   #hero-option-signal-grid:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-signal-grid"] {
     border-color: color-mix(
       in srgb,
@@ -324,44 +276,44 @@ const heroBootstrapScript = `
   }
 
   #hero-option-launchpad:focus-visible
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-launchpad"],
   #hero-option-control-room:focus-visible
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-control-room"],
   #hero-option-blueprint:focus-visible
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-blueprint"],
   #hero-option-release-train:focus-visible
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-release-train"],
   #hero-option-operator-desk:focus-visible
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-operator-desk"],
   #hero-option-signal-grid:focus-visible
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__controls
     label[for="hero-option-signal-grid"] {
     outline: 2px solid var(--color-accent-cyan);
     outline-offset: 3px;
   }
 
   #hero-option-launchpad:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__panels
     .hero-showcase__panel--launchpad,
   #hero-option-control-room:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__panels
     .hero-showcase__panel--control-room,
   #hero-option-blueprint:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__panels
     .hero-showcase__panel--blueprint,
   #hero-option-release-train:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__panels
     .hero-showcase__panel--release-train,
   #hero-option-operator-desk:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__panels
     .hero-showcase__panel--operator-desk,
   #hero-option-signal-grid:checked
-    ~ .hero-showcase__shell
+    ~ .hero-showcase__panels
     .hero-showcase__panel--signal-grid {
     display: block;
     animation: hero-panel-in 0.35s cubic-bezier(0.16, 1, 0.3, 1);
@@ -375,19 +327,6 @@ const heroBootstrapScript = `
     to {
       opacity: 1;
       transform: translateY(0);
-    }
-  }
-
-  @media (min-width: 64rem) {
-    .hero-showcase__toolbar {
-      grid-template-columns: auto minmax(0, 1fr);
-      gap: 1rem;
-    }
-
-    .hero-showcase__controls {
-      justify-content: flex-end;
-      overflow: visible;
-      padding-bottom: 0;
     }
   }
 </style>

--- a/frontend/src/components/heroes/HeroShowcase.astro
+++ b/frontend/src/components/heroes/HeroShowcase.astro
@@ -51,9 +51,17 @@ const heroBootstrapScript = `
 (() => {
   const STORAGE_KEY = "shockstack:homepage-hero";
   const HERO_IDS = ${JSON.stringify(heroOptions.map((option) => option.id))};
+  const HERO_META = ${JSON.stringify(
+    Object.fromEntries(
+      heroOptions.map((o) => [o.id, { label: o.label, accent: o.accent }]),
+    ),
+  )};
   const DEFAULT_HERO = "${defaultHero}";
   const ROOT_SELECTOR = "[data-hero-showcase]";
   const INPUT_SELECTOR = 'input[name="homepage-hero"]';
+  const PICKER_SELECTOR = "[data-hero-picker]";
+  const TRIGGER_SELECTOR = "[data-hero-picker-trigger]";
+  const FLOATING_OFFSET = 96;
 
   function resolveInitialHero() {
     const url = new URL(window.location.href);
@@ -78,11 +86,18 @@ const heroBootstrapScript = `
     const root = document.querySelector(ROOT_SELECTOR);
     if (!(root instanceof HTMLElement)) return;
 
+    const picker = root.querySelector(PICKER_SELECTOR);
+    const trigger = root.querySelector(TRIGGER_SELECTOR);
+    const triggerLabel = trigger?.querySelector("[data-hero-picker-trigger-label]");
+    const triggerDot = trigger?.querySelector("[data-hero-picker-trigger-dot]");
     const inputs = Array.from(root.querySelectorAll(INPUT_SELECTOR)).filter(
       (input) => input instanceof HTMLInputElement,
     );
 
+    if (!picker || !(picker instanceof HTMLElement)) return;
     if (!inputs.length) return;
+
+    const closePicker = () => picker.classList.remove("is-expanded");
 
     const applyHero = (value) => {
       const nextInput =
@@ -93,6 +108,18 @@ const heroBootstrapScript = `
       document.documentElement.dataset.heroVariant = nextInput.value;
       localStorage.setItem(STORAGE_KEY, nextInput.value);
       syncUrl(nextInput.value);
+
+      const meta = HERO_META[nextInput.value];
+      if (meta && triggerLabel) triggerLabel.textContent = meta.label;
+      if (meta && trigger instanceof HTMLElement) {
+        trigger.style.setProperty(
+          "--hero-option-accent",
+          "var(--color-accent-" + meta.accent + ")",
+        );
+      }
+      if (meta && triggerDot instanceof HTMLElement) {
+        triggerDot.style.background = "var(--color-accent-" + meta.accent + ")";
+      }
     };
 
     if (root.dataset.bound !== "true") {
@@ -100,8 +127,60 @@ const heroBootstrapScript = `
         input.addEventListener("change", () => {
           if (!input.checked) return;
           applyHero(input.value);
+          closePicker();
         });
       }
+
+      // intercept label clicks so the hidden radio doesn't pull focus
+      // (focus lands at the top of the page, which scrolls past the hero)
+      const labels = root.querySelectorAll(".hero-picker__option");
+      for (const label of labels) {
+        label.addEventListener("click", (event) => {
+          event.preventDefault();
+          const forId = label.getAttribute("for");
+          if (!forId) return;
+          const input = inputs.find((i) => i.id === forId);
+          if (!input) return;
+          if (!input.checked) {
+            input.checked = true;
+            input.dispatchEvent(new Event("change", { bubbles: true }));
+          } else {
+            closePicker();
+          }
+        });
+      }
+
+      if (trigger instanceof HTMLElement) {
+        trigger.addEventListener("click", (event) => {
+          event.stopPropagation();
+          picker.classList.toggle("is-expanded");
+          const expanded = picker.classList.contains("is-expanded");
+          trigger.setAttribute("aria-expanded", String(expanded));
+        });
+      }
+
+      document.addEventListener("click", (event) => {
+        if (!picker.classList.contains("is-expanded")) return;
+        if (!(event.target instanceof Node)) return;
+        if (picker.contains(event.target)) return;
+        closePicker();
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") closePicker();
+      });
+
+      const updateFloating = () => {
+        const rect = root.getBoundingClientRect();
+        const shouldFloat = rect.bottom < FLOATING_OFFSET;
+        picker.classList.toggle("is-floating", shouldFloat);
+        if (!shouldFloat) closePicker();
+      };
+
+      window.addEventListener("scroll", updateFloating, { passive: true });
+      window.addEventListener("resize", updateFloating);
+      updateFloating();
+
       root.dataset.bound = "true";
     }
 
@@ -128,29 +207,63 @@ const heroBootstrapScript = `
         id={`hero-option-${option.id}`}
         value={option.id}
         checked={index === 0}
+        tabindex="-1"
+        aria-hidden="true"
       />
     ))
   }
 
   <script is:inline set:html={heroBootstrapScript} />
 
-  <div
-    class="hero-showcase__controls"
-    role="radiogroup"
-    aria-label="Homepage hero style"
-  >
-    {
-      heroOptions.map((option) => (
-        <label
-          class="hero-showcase__option"
-          for={`hero-option-${option.id}`}
-          style={`--hero-option-accent: var(--color-accent-${option.accent})`}
-        >
-          <span class="hero-showcase__option-dot" />
-          <span class="hero-showcase__option-name">{option.label}</span>
-        </label>
-      ))
-    }
+  <div class="hero-picker" data-hero-picker>
+    <button
+      class="hero-picker__trigger"
+      data-hero-picker-trigger
+      type="button"
+      aria-expanded="false"
+      aria-label="Change hero style"
+    >
+      <span
+        class="hero-picker__trigger-dot"
+        data-hero-picker-trigger-dot
+        aria-hidden="true"></span>
+      <span class="hero-picker__trigger-label" data-hero-picker-trigger-label>
+        Launchpad
+      </span>
+      <svg
+        class="hero-picker__trigger-caret"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <polyline points="18 15 12 9 6 15"></polyline>
+      </svg>
+    </button>
+
+    <div
+      class="hero-picker__options"
+      role="radiogroup"
+      aria-label="Homepage hero style"
+    >
+      {
+        heroOptions.map((option, index) => (
+          <label
+            class="hero-picker__option"
+            for={`hero-option-${option.id}`}
+            style={`--hero-option-accent: var(--color-accent-${option.accent}); --hero-option-index: ${index}`}
+          >
+            <span class="hero-picker__option-dot" />
+            <span class="hero-picker__option-name">{option.label}</span>
+          </label>
+        ))
+      }
+    </div>
   </div>
 
   <div class="hero-showcase__panels">
@@ -178,6 +291,8 @@ const heroBootstrapScript = `
 <style>
   .hero-showcase {
     position: relative;
+    padding-top: 4.75rem;
+    padding-bottom: 1rem;
   }
 
   .hero-showcase__input {
@@ -186,7 +301,12 @@ const heroBootstrapScript = `
     pointer-events: none;
   }
 
-  .hero-showcase__controls {
+  /* ----- PICKER: shared ----- */
+  .hero-picker {
+    --picker-fab-size: 3rem;
+  }
+
+  .hero-picker__options {
     position: fixed;
     top: 4.75rem;
     left: 50%;
@@ -207,19 +327,22 @@ const heroBootstrapScript = `
     border: 1px solid
       color-mix(in srgb, var(--color-border-default) 65%, transparent);
     box-shadow: 0 10px 30px -18px rgba(0, 0, 0, 0.45);
+    transition:
+      top 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+      left 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+      right 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+      bottom 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+      transform 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+      opacity 0.25s ease,
+      border-radius 0.4s ease,
+      padding 0.4s ease;
   }
 
-  .hero-showcase__controls::-webkit-scrollbar {
+  .hero-picker__options::-webkit-scrollbar {
     display: none;
   }
 
-  /* reserve space so the fixed picker doesn't overlap the hero title */
-  .hero-showcase {
-    padding-top: 4.5rem;
-    padding-bottom: 1rem;
-  }
-
-  .hero-showcase__option {
+  .hero-picker__option {
     position: relative;
     display: inline-flex;
     align-items: center;
@@ -235,10 +358,11 @@ const heroBootstrapScript = `
       transform 0.25s cubic-bezier(0.16, 1, 0.3, 1),
       border-color 0.25s ease,
       box-shadow 0.25s ease,
-      background-color 0.25s ease;
+      background-color 0.25s ease,
+      opacity 0.3s ease;
   }
 
-  .hero-showcase__option-dot {
+  .hero-picker__option-dot {
     display: inline-block;
     height: 0.5rem;
     width: 0.5rem;
@@ -248,7 +372,7 @@ const heroBootstrapScript = `
       color-mix(in srgb, var(--hero-option-accent) 14%, transparent);
   }
 
-  .hero-showcase__option:hover {
+  .hero-picker__option:hover {
     transform: translateY(-1px);
     border-color: color-mix(
       in srgb,
@@ -257,38 +381,31 @@ const heroBootstrapScript = `
     );
   }
 
-  .hero-showcase__option-name {
+  .hero-picker__option-name {
     font-size: 0.85rem;
     font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
   }
 
-  .hero-showcase__panels {
-    position: relative;
-  }
-
-  .hero-showcase__panel {
-    display: none;
-  }
-
+  /* checked styles driven by hidden radio inputs on .hero-showcase */
   #hero-option-launchpad:checked
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-launchpad"],
   #hero-option-control-room:checked
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-control-room"],
   #hero-option-blueprint:checked
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-blueprint"],
   #hero-option-release-train:checked
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-release-train"],
   #hero-option-operator-desk:checked
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-operator-desk"],
   #hero-option-signal-grid:checked
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-signal-grid"] {
     border-color: color-mix(
       in srgb,
@@ -301,25 +418,202 @@ const heroBootstrapScript = `
   }
 
   #hero-option-launchpad:focus-visible
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-launchpad"],
   #hero-option-control-room:focus-visible
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-control-room"],
   #hero-option-blueprint:focus-visible
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-blueprint"],
   #hero-option-release-train:focus-visible
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-release-train"],
   #hero-option-operator-desk:focus-visible
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-operator-desk"],
   #hero-option-signal-grid:focus-visible
-    ~ .hero-showcase__controls
+    ~ .hero-picker
     label[for="hero-option-signal-grid"] {
     outline: 2px solid var(--color-accent-cyan);
     outline-offset: 3px;
+  }
+
+  /* ----- PICKER TRIGGER (FAB) ----- */
+  .hero-picker__trigger {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 41;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.65rem 1rem 0.65rem 0.85rem;
+    border-radius: var(--radius-full);
+    border: 1px solid
+      color-mix(in srgb, var(--color-border-default) 70%, transparent);
+    background: color-mix(in srgb, var(--color-bg-primary) 82%, transparent);
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    color: var(--color-fg-primary);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(12px) scale(0.92);
+    pointer-events: none;
+    box-shadow:
+      0 12px 30px -18px rgba(0, 0, 0, 0.55),
+      0 0 0 1px
+        color-mix(
+          in srgb,
+          var(--hero-option-accent, transparent) 20%,
+          transparent
+        )
+        inset;
+    transition:
+      opacity 0.3s ease,
+      transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+      border-color 0.25s ease,
+      box-shadow 0.25s ease;
+  }
+
+  .hero-picker__trigger:hover {
+    border-color: color-mix(
+      in srgb,
+      var(--hero-option-accent, var(--color-border-default)) 50%,
+      var(--color-border-default)
+    );
+    transform: translateY(0) scale(1) translateZ(0);
+  }
+
+  .hero-picker__trigger-dot {
+    display: inline-block;
+    height: 0.55rem;
+    width: 0.55rem;
+    border-radius: 999px;
+    background: var(--color-accent-cyan);
+    box-shadow: 0 0 0 0.28rem color-mix(in srgb, currentColor 0%, transparent);
+  }
+
+  .hero-picker__trigger-caret {
+    transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    opacity: 0.7;
+  }
+
+  .hero-picker.is-expanded .hero-picker__trigger-caret {
+    transform: rotate(180deg);
+  }
+
+  /* ----- FLOATING STATE ----- */
+  .hero-picker.is-floating .hero-picker__trigger {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+  }
+
+  .hero-picker.is-floating .hero-picker__options {
+    top: auto;
+    left: auto;
+    right: 1rem;
+    bottom: calc(1rem + var(--picker-fab-size) + 0.75rem);
+    transform: translateX(0) translateY(8px) scale(0.96);
+    transform-origin: bottom right;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    padding: 0.55rem;
+    gap: 0.3rem;
+    max-width: min(16rem, calc(100vw - 2rem));
+    border-radius: var(--radius-xl);
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .hero-picker.is-floating.is-expanded .hero-picker__options {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0) translateY(0) scale(1);
+  }
+
+  .hero-picker.is-floating .hero-picker__option {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+    transition:
+      opacity 0.3s ease,
+      transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+      border-color 0.25s ease,
+      background-color 0.25s ease,
+      box-shadow 0.25s ease;
+    transition-delay: 0s;
+  }
+
+  .hero-picker.is-floating.is-expanded .hero-picker__option {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    transition-delay: calc(var(--hero-option-index) * 0.035s + 0.05s);
+  }
+
+  /* ----- MOBILE: always floating ----- */
+  @media (max-width: 639px) {
+    .hero-showcase {
+      padding-top: 1.5rem;
+    }
+
+    .hero-picker__trigger {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      pointer-events: auto;
+    }
+
+    .hero-picker__options {
+      top: auto;
+      left: auto;
+      right: 1rem;
+      bottom: calc(1rem + var(--picker-fab-size) + 0.75rem);
+      transform: translateX(0) translateY(8px) scale(0.96);
+      transform-origin: bottom right;
+      flex-direction: column;
+      align-items: stretch;
+      padding: 0.55rem;
+      gap: 0.3rem;
+      max-width: min(16rem, calc(100vw - 2rem));
+      border-radius: var(--radius-xl);
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .hero-picker.is-expanded .hero-picker__options {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(0) translateY(0) scale(1);
+    }
+
+    .hero-picker__option {
+      opacity: 0;
+      transform: translateY(6px) scale(0.98);
+      transition:
+        opacity 0.3s ease,
+        transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+        border-color 0.25s ease,
+        background-color 0.25s ease,
+        box-shadow 0.25s ease;
+    }
+
+    .hero-picker.is-expanded .hero-picker__option {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      transition-delay: calc(var(--hero-option-index) * 0.035s + 0.05s);
+    }
+  }
+
+  /* ----- PANELS ----- */
+  .hero-showcase__panels {
+    position: relative;
+  }
+
+  .hero-showcase__panel {
+    display: none;
   }
 
   #hero-option-launchpad:checked
@@ -352,6 +646,15 @@ const heroBootstrapScript = `
     to {
       opacity: 1;
       transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-picker__options,
+    .hero-picker__trigger,
+    .hero-picker__option,
+    .hero-picker__trigger-caret {
+      transition: opacity 0.15s ease;
     }
   }
 </style>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -574,15 +574,15 @@ const featuredUseCases = stackUseCases.slice(0, 3);
   <section class="reveal border-border-default border-t px-4 py-16 md:py-20">
     <div class="mx-auto max-w-2xl text-center">
       <p class="text-fg-muted mb-2 font-mono text-xs tracking-wider uppercase">
-        Need a team to build it for you?
+        Need someone to build it for you?
       </p>
       <h3 class="mb-4 text-2xl font-bold md:text-3xl">
         Let <span class="text-accent-cyan">Spectacle Software</span> handle it
       </h3>
       <p class="text-fg-secondary mx-auto mb-8 max-w-lg text-base">
-        The team behind ShockStack builds custom web applications, APIs, and
-        full-stack platforms for businesses. Same stack, same quality &mdash;
-        tailored to your needs.
+        The one man team behind ShockStack builds custom web applications, APIs,
+        and full-stack platforms for businesses. Same stack, same quality
+        &mdash; tailored to your needs.
       </p>
       <a
         href="https://spectaclesoftware.com"

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -696,6 +696,84 @@ const featuredUseCases = stackUseCases.slice(0, 3);
       color-mix(in srgb, var(--color-accent-cyan) 30%, transparent) inset;
   }
 
+  /* hero variant: blueprint — purple grid-paper feel with dashed borders */
+  :global([data-hero-variant="blueprint"]) .features-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      linear-gradient(
+        to right,
+        color-mix(in srgb, var(--color-accent-purple) 8%, transparent) 1px,
+        transparent 1px
+      ),
+      linear-gradient(
+        to bottom,
+        color-mix(in srgb, var(--color-accent-purple) 8%, transparent) 1px,
+        transparent 1px
+      );
+    background-size: 48px 48px;
+    mask-image: radial-gradient(ellipse at 50% 40%, black 35%, transparent 85%);
+    opacity: 0;
+    animation: features-fade-in 0.45s ease forwards;
+  }
+
+  :global([data-hero-variant="blueprint"]) .features-title {
+    color: var(--color-fg-primary);
+    letter-spacing: -0.02em;
+  }
+
+  :global([data-hero-variant="blueprint"]) .features-title::after {
+    content: "";
+    display: block;
+    width: 3rem;
+    height: 2px;
+    margin: 0.85rem auto 0;
+    background: linear-gradient(
+      90deg,
+      var(--color-accent-purple),
+      var(--color-accent-pink)
+    );
+  }
+
+  :global([data-hero-variant="blueprint"]) .feature-card {
+    border: 1px dashed
+      color-mix(
+        in srgb,
+        var(--color-accent-purple) 45%,
+        var(--color-border-default)
+      );
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-bg-secondary) 85%, transparent),
+      color-mix(in srgb, var(--color-bg-primary) 96%, transparent)
+    );
+    box-shadow: none;
+  }
+
+  :global([data-hero-variant="blueprint"]) .feature-card:hover {
+    border-style: solid;
+    border-color: color-mix(
+      in srgb,
+      var(--color-accent-purple) 55%,
+      var(--color-border-default)
+    );
+    box-shadow: 0 18px 40px -32px
+      color-mix(in srgb, var(--color-accent-purple) 60%, transparent);
+  }
+
+  :global([data-hero-variant="blueprint"]) .feature-icon {
+    border-radius: 0;
+    background: color-mix(
+      in srgb,
+      var(--color-bg-primary) 70%,
+      color-mix(in srgb, var(--color-accent-purple) 20%, transparent)
+    );
+    box-shadow: 0 0 0 1px
+      color-mix(in srgb, var(--color-accent-purple) 35%, transparent) inset;
+  }
+
   @keyframes features-fade-in {
     to {
       opacity: 1;

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -774,6 +774,109 @@ const featuredUseCases = stackUseCases.slice(0, 3);
       color-mix(in srgb, var(--color-accent-purple) 35%, transparent) inset;
   }
 
+  /* hero variant: release-train — orange ship-it energy */
+  :global([data-hero-variant="release-train"]) .features-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      linear-gradient(
+        115deg,
+        color-mix(in srgb, var(--color-accent-orange) 9%, transparent),
+        transparent 45%
+      ),
+      linear-gradient(
+        295deg,
+        color-mix(in srgb, var(--color-accent-yellow) 6%, transparent),
+        transparent 50%
+      );
+    opacity: 0;
+    animation: features-fade-in 0.45s ease forwards;
+  }
+
+  :global([data-hero-variant="release-train"]) .features-title {
+    text-transform: uppercase;
+    letter-spacing: -0.01em;
+    font-weight: 800;
+  }
+
+  :global([data-hero-variant="release-train"]) .features-lede {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+  }
+
+  :global([data-hero-variant="release-train"]) .feature-card {
+    border: 1px solid
+      color-mix(
+        in srgb,
+        var(--color-accent-orange) 30%,
+        var(--color-border-default)
+      );
+    background: linear-gradient(
+      160deg,
+      color-mix(in srgb, var(--color-bg-secondary) 94%, transparent),
+      color-mix(in srgb, var(--color-bg-primary) 96%, transparent)
+    );
+    box-shadow:
+      0 0 0 0 color-mix(in srgb, var(--color-accent-orange) 0%, transparent),
+      0 22px 44px -34px
+        color-mix(in srgb, var(--color-accent-orange) 55%, transparent);
+    position: relative;
+    overflow: hidden;
+  }
+
+  :global([data-hero-variant="release-train"]) .feature-card::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: linear-gradient(
+      180deg,
+      var(--color-accent-orange),
+      var(--color-accent-yellow)
+    );
+    transform: scaleY(0.6);
+    transform-origin: center;
+    transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  :global([data-hero-variant="release-train"]) .feature-card:hover {
+    border-color: color-mix(
+      in srgb,
+      var(--color-accent-orange) 55%,
+      var(--color-border-default)
+    );
+    transform: translateX(2px);
+  }
+
+  :global([data-hero-variant="release-train"]) .feature-card:hover::before {
+    transform: scaleY(1);
+  }
+
+  :global([data-hero-variant="release-train"]) .feature-icon {
+    border-radius: var(--radius-sm);
+    background: linear-gradient(
+      135deg,
+      color-mix(
+        in srgb,
+        var(--color-accent-orange) 25%,
+        var(--color-bg-tertiary)
+      ),
+      color-mix(
+        in srgb,
+        var(--color-accent-yellow) 15%,
+        var(--color-bg-tertiary)
+      )
+    );
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+      0 4px 12px -8px
+        color-mix(in srgb, var(--color-accent-orange) 70%, transparent);
+  }
+
   @keyframes features-fade-in {
     to {
       opacity: 1;

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -652,6 +652,9 @@ const featuredUseCases = stackUseCases.slice(0, 3);
     background-clip: text;
     -webkit-background-clip: text;
     color: transparent;
+    display: inline-block;
+    padding-bottom: 0.15em;
+    line-height: 1.2;
   }
 
   :global([data-hero-variant="launchpad"]) .feature-card {

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -17,19 +17,19 @@ const featuredUseCases = stackUseCases.slice(0, 3);
   <HeroShowcase />
 
   <!-- features grid -->
-  <section class="reveal px-4 py-20 md:py-28">
+  <section class="reveal features-section px-4 py-20 md:py-28">
     <div class="mx-auto max-w-6xl">
-      <div class="mb-16 text-center">
-        <h2 class="mb-4 text-3xl font-bold md:text-4xl">
+      <div class="features-header mb-16 text-center">
+        <h2 class="features-title mb-4 text-3xl font-bold md:text-4xl">
           Everything you need, nothing you don't
         </h2>
-        <p class="text-fg-secondary mx-auto max-w-2xl text-lg">
+        <p class="features-lede text-fg-secondary mx-auto max-w-2xl text-lg">
           Batteries included where it matters. Every piece is optional,
           swappable, and documented.
         </p>
       </div>
 
-      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div class="features-grid grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <div class="glass hover-lift feature-card group">
           <div class="feature-icon text-accent-orange">
             <svg
@@ -598,9 +598,19 @@ const featuredUseCases = stackUseCases.slice(0, 3);
 
 <style>
   /* feature cards */
+  .features-section {
+    position: relative;
+    transition: background-color 0.35s ease;
+  }
+
   .feature-card {
     border-radius: var(--radius-xl);
     padding: 1.5rem;
+    transition:
+      border-color 0.35s ease,
+      background 0.35s ease,
+      box-shadow 0.35s ease,
+      transform 0.35s ease;
   }
 
   .feature-icon {
@@ -612,6 +622,84 @@ const featuredUseCases = stackUseCases.slice(0, 3);
     border-radius: var(--radius-lg);
     background-color: var(--color-bg-tertiary);
     margin-bottom: 1rem;
+    transition:
+      background-color 0.35s ease,
+      box-shadow 0.35s ease,
+      border-radius 0.35s ease;
+  }
+
+  /* hero variant: launchpad — cyan glow, subtle grid overlay */
+  :global([data-hero-variant="launchpad"]) .features-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      circle at 50% 0%,
+      color-mix(in srgb, var(--color-accent-cyan) 10%, transparent),
+      transparent 55%
+    );
+    opacity: 0;
+    animation: features-fade-in 0.45s ease forwards;
+  }
+
+  :global([data-hero-variant="launchpad"]) .features-title {
+    background: linear-gradient(
+      120deg,
+      var(--color-fg-primary),
+      var(--color-accent-cyan)
+    );
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+  }
+
+  :global([data-hero-variant="launchpad"]) .feature-card {
+    border: 1px solid
+      color-mix(
+        in srgb,
+        var(--color-accent-cyan) 22%,
+        var(--color-border-default)
+      );
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-bg-secondary) 92%, transparent),
+      color-mix(in srgb, var(--color-bg-primary) 94%, transparent)
+    );
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--color-accent-cyan) 18%, transparent)
+        inset,
+      0 18px 40px -30px
+        color-mix(in srgb, var(--color-accent-cyan) 40%, transparent);
+  }
+
+  :global([data-hero-variant="launchpad"]) .feature-card:hover {
+    border-color: color-mix(
+      in srgb,
+      var(--color-accent-cyan) 50%,
+      var(--color-border-default)
+    );
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--color-accent-cyan) 28%, transparent)
+        inset,
+      0 24px 48px -28px
+        color-mix(in srgb, var(--color-accent-cyan) 55%, transparent);
+  }
+
+  :global([data-hero-variant="launchpad"]) .feature-icon {
+    background: color-mix(
+      in srgb,
+      var(--color-bg-tertiary) 60%,
+      color-mix(in srgb, var(--color-accent-cyan) 20%, transparent)
+    );
+    box-shadow: 0 0 0 1px
+      color-mix(in srgb, var(--color-accent-cyan) 30%, transparent) inset;
+  }
+
+  @keyframes features-fade-in {
+    to {
+      opacity: 1;
+    }
   }
 
   /* stack visualization */

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -877,6 +877,84 @@ const featuredUseCases = stackUseCases.slice(0, 3);
         color-mix(in srgb, var(--color-accent-orange) 70%, transparent);
   }
 
+  /* hero variant: operator-desk — pink warm tactile elevation */
+  :global([data-hero-variant="operator-desk"]) .features-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      ellipse at 30% 15%,
+      color-mix(in srgb, var(--color-accent-pink) 10%, transparent),
+      transparent 55%
+    );
+    opacity: 0;
+    animation: features-fade-in 0.45s ease forwards;
+  }
+
+  :global([data-hero-variant="operator-desk"]) .features-title {
+    letter-spacing: -0.025em;
+    color: var(--color-fg-primary);
+  }
+
+  :global([data-hero-variant="operator-desk"]) .features-lede {
+    font-style: italic;
+  }
+
+  :global([data-hero-variant="operator-desk"]) .feature-card {
+    border: 1px solid
+      color-mix(
+        in srgb,
+        var(--color-accent-pink) 18%,
+        var(--color-border-default)
+      );
+    background: linear-gradient(
+      165deg,
+      color-mix(
+        in srgb,
+        var(--color-accent-pink) 5%,
+        var(--color-bg-secondary)
+      ),
+      color-mix(in srgb, var(--color-bg-primary) 98%, transparent)
+    );
+    box-shadow:
+      0 1px 0 color-mix(in srgb, white 5%, transparent) inset,
+      0 24px 50px -32px
+        color-mix(in srgb, var(--color-accent-pink) 35%, transparent),
+      0 4px 12px -8px color-mix(in srgb, black 40%, transparent);
+  }
+
+  :global([data-hero-variant="operator-desk"]) .feature-card:hover {
+    border-color: color-mix(
+      in srgb,
+      var(--color-accent-pink) 40%,
+      var(--color-border-default)
+    );
+    transform: translateY(-3px) rotate(-0.15deg);
+    box-shadow:
+      0 1px 0 color-mix(in srgb, white 8%, transparent) inset,
+      0 32px 60px -28px
+        color-mix(in srgb, var(--color-accent-pink) 50%, transparent),
+      0 6px 16px -8px color-mix(in srgb, black 45%, transparent);
+  }
+
+  :global([data-hero-variant="operator-desk"]) .feature-icon {
+    border-radius: 9999px;
+    background: radial-gradient(
+      circle at 30% 30%,
+      color-mix(
+        in srgb,
+        var(--color-accent-pink) 28%,
+        var(--color-bg-tertiary)
+      ),
+      var(--color-bg-tertiary) 72%
+    );
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, white 12%, transparent),
+      0 4px 10px -4px
+        color-mix(in srgb, var(--color-accent-pink) 40%, transparent);
+  }
+
   @keyframes features-fade-in {
     to {
       opacity: 1;


### PR DESCRIPTION
## Summary
- De-nest HeroShowcase: drop the outer section/mesh wrapper, strip the card framing from each hero panel, and make the switcher pills sticky with a translucent backdrop so they scroll with the page.
- Set `data-hero-variant` on `<html>` so other components can react to the active hero style.
- Add four theme variants for the "Everything you need, nothing you don't" section that activate when the matching hero is selected: **launchpad** (cyan glow), **blueprint** (dashed purple grid), **release-train** (orange motion bar), **operator-desk** (pink tactile tilt).
- Fix descender clipping (g/p glyphs) on gradient-clipped titles in the launchpad hero and features section.

## Test plan
- [ ] visit `/` — switcher pills stick to the top while scrolling
- [ ] cycle all six heroes — each renders flat inside the page flow (no floating card)
- [ ] verify "lightning speed" and "Everything you need, nothing you don't" descenders render fully
- [ ] confirm features section restyles on launchpad / blueprint / release-train / operator-desk
- [ ] confirm control-room and signal-grid leave the features section at the default style
- [ ] check with `prefers-reduced-motion` — no jarring animations