### PR TITLE
ci: bump repo-sentinel to v0.2.2

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   security-scan:
-    uses: codywilliamson/repo-sentinel/.github/workflows/security-scan.yml@v0.2.1
+    uses: codywilliamson/repo-sentinel/.github/workflows/security-scan.yml@v0.2.2
     with:
       ## minimum severity to create issues for (LOW, MEDIUM, HIGH, CRITICAL)
       severity-threshold: "MEDIUM"


### PR DESCRIPTION
## Summary
- Bumps repo-sentinel reusable workflow references to `v0.2.2`.
- Picks up the workflow permission fix that removes the unnecessary `pull-requests: write` request.

## Validation
- `git diff --check`